### PR TITLE
fix: allow new line in code block

### DIFF
--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -102,7 +102,7 @@ codeBlock
 }
 
 codeBlockContent
-	= (!(LF "```" END) CHAR)+
+	= (!(LF "```" END) .)+
 { return text(); }
 
 // block: mathBlock


### PR DESCRIPTION
Fix #38 

なおテストは https://github.com/misskey-dev/mfm.js/commit/f28c9ed86f06b014d57631d9cf965bc84982794b で追加済み。