### PR TITLE
fix: hashtag can not include XML tags

### DIFF
--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -355,7 +355,7 @@ hashtagBracketPair
 	/ "「" hashtagContent* "」"
 
 hashtagChar
-	= ![ 　\t.,!?'"#:\/\[\]【】()「」] CHAR
+	= ![ 　\t.,!?'"#:\/\[\]【】()「」<>] CHAR
 
 // inline: URL
 

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -716,6 +716,12 @@ hoge`;
 			assert.deepStrictEqual(mfm.parse(input), output);
 		});
 
+		it('ignore angle bracket', () => {
+			const input = '#foo<bar>';
+			const output = [HASHTAG('foo'), TEXT('<bar>')];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
 		it('allow including number', () => {
 			const input = '#foo123';
 			const output = [HASHTAG('foo123')];


### PR DESCRIPTION
# What

Disallow `<` and `>` in hashtags.

# Why

`<center>#hashtag</center>`
&dArr;
```javascript
[
    TEXT('<center>'),
    HASHTAG('hashtag<'),
    TEXT('/center')
]
```

found at https://mk.absturztau.be/notes/8pwvi4txxg