### PR TITLE
add bold and strikethrough HTML

### DIFF
--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -242,6 +242,10 @@ bold
 {
 	return BOLD(mergeText(content));
 }
+	/ "<b>" content:(!"</b>" i:inline { return i; })+ "</b>"
+{
+	return BOLD(mergeText(content));
+}
 	/ "__" content:$(!"__" c:([a-z0-9]i / _) { return c; })+ "__"
 {
 	const parsedContent = applyParser(content, 'inlineParser');
@@ -284,6 +288,10 @@ italicAlt
 
 strike
 	= "~~" content:(!("~" / LF) i:inline { return i; })+ "~~"
+{
+	return STRIKE(mergeText(content));
+}
+	/ "<s>" content:(!("</s>" / LF) i:inline { return i; })+ "</s>"
 {
 	return STRIKE(mergeText(content));
 }

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -362,6 +362,44 @@ hoge`;
 		});
 	});
 
+	describe('bold tag', () => {
+		it('basic', () => {
+			const input = '<b>abc</b>';
+			const output = [
+				BOLD([
+					TEXT('abc')
+				])
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+		it('inline syntax allowed inside', () => {
+			const input = '<b>123~~abc~~123</b>';
+			const output = [
+				BOLD([
+					TEXT('123'),
+					STRIKE([
+						TEXT('abc')
+					]),
+					TEXT('123')
+				])
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+		it('line breaks', () => {
+			const input = '<b>123\n~~abc~~\n123</b>';
+			const output = [
+				BOLD([
+					TEXT('123\n'),
+					STRIKE([
+						TEXT('abc')
+					]),
+					TEXT('\n123')
+				])
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+	});
+
 	describe('bold', () => {
 		it('basic', () => {
 			const input = '**abc**';
@@ -552,6 +590,16 @@ hoge`;
 				]),
 				TEXT('えお')
 			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+	});
+
+	describe('strike tag', () => {
+		it('basic', () => {
+			const input = '<s>foo</s>';
+			const output = [STRIKE([
+				TEXT('foo')
+			])];
 			assert.deepStrictEqual(mfm.parse(input), output);
 		});
 	});


### PR DESCRIPTION
# What
Add the HTML tags for bold (`<b>`) and strikethrough (`<s>`). Also added tests.

# Why
fix #75
