### PR TITLE
Introduce nesting limit

### DIFF
--- a/etc/mfm-js.api.md
+++ b/etc/mfm-js.api.md
@@ -233,7 +233,7 @@ export type NodeType<T extends MfmNode['type']> = T extends 'quote' ? MfmQuote :
 // @public (undocumented)
 export function parse(input: string, opts?: Partial<{
     fnNameList: string[];
-    fnDepthLimit: number;
+    nestLimit: number;
 }>): MfmNode[];
 
 // Warning: (ae-forgotten-export) The symbol "MfmPlainNode" needs to be exported by the entry point index.d.ts

--- a/etc/mfm-js.api.md
+++ b/etc/mfm-js.api.md
@@ -233,6 +233,7 @@ export type NodeType<T extends MfmNode['type']> = T extends 'quote' ? MfmQuote :
 // @public (undocumented)
 export function parse(input: string, opts?: Partial<{
     fnNameList: string[];
+    fnDepthLimit: number;
 }>): MfmNode[];
 
 // Warning: (ae-forgotten-export) The symbol "MfmPlainNode" needs to be exported by the entry point index.d.ts

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,11 @@ const parser: peg.Parser = require('./internal/parser');
  * Generates a MfmNode tree from the MFM string.
 */
 export function parse(input: string, opts: Partial<{ fnNameList: string[]; fnDepthLimit: number; }> = {}): MfmNode[] {
-	const nodes = parser.parse(input, { startRule: 'fullParser', fnNameList: opts.fnNameList });
+	const nodes = parser.parse(input, {
+		startRule: 'fullParser',
+		fnNameList: opts.fnNameList,
+		fnDepthLimit: opts.fnDepthLimit
+	});
 	return nodes;
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,11 +8,11 @@ const parser: peg.Parser = require('./internal/parser');
 /**
  * Generates a MfmNode tree from the MFM string.
 */
-export function parse(input: string, opts: Partial<{ fnNameList: string[]; fnDepthLimit: number; }> = {}): MfmNode[] {
+export function parse(input: string, opts: Partial<{ fnNameList: string[]; nestLimit: number; }> = {}): MfmNode[] {
 	const nodes = parser.parse(input, {
 		startRule: 'fullParser',
 		fnNameList: opts.fnNameList,
-		fnDepthLimit: opts.fnDepthLimit
+		nestLimit: opts.nestLimit
 	});
 	return nodes;
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,7 @@ const parser: peg.Parser = require('./internal/parser');
 /**
  * Generates a MfmNode tree from the MFM string.
 */
-export function parse(input: string, opts: Partial<{ fnNameList: string[]; }> = {}): MfmNode[] {
+export function parse(input: string, opts: Partial<{ fnNameList: string[]; fnDepthLimit: number; }> = {}): MfmNode[] {
 	const nodes = parser.parse(input, { startRule: 'fullParser', fnNameList: opts.fnNameList });
 	return nodes;
 }

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -65,25 +65,25 @@
 		return options.fnNameList.includes(name);
 	}
 
-	// fn
+	// nesting control
 
-	const fnDepthLimit = options.fnDepthLimit || 10;
-	let fnDepth = 0;
-	function enterFn() {
-		if (fnDepth + 1 > fnDepthLimit) {
+	const nestLimit = options.nestLimit || 10;
+	let depth = 0;
+	function enterNest() {
+		if (depth + 1 > nestLimit) {
 			return false;
 		}
-		fnDepth++;
+		depth++;
 		return true;
 	}
 
-	function leaveFn() {
-		fnDepth--;
+	function leaveNest() {
+		depth--;
 		return true;
 	}
 
-	function fallbackFn() {
-		fnDepth--;
+	function fallbackNest() {
+		depth--;
 		return false;
 	}
 }
@@ -448,7 +448,7 @@ fn
 }
 
 fnContent
-	= &{ return enterFn(); } @(@(!("]") @inline)+ &{ return leaveFn(); } / &{ return fallbackFn(); })
+	= &{ return enterNest(); } @(@(!("]") @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
 
 fnArgs
 	= "." head:fnArg tails:("," @fnArg)*

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -396,9 +396,12 @@ hashtagContentPart
 	/ hashtagChar
 
 hashtagBracketPair
-	= "(" hashtagContentPart* ")"
-	/ "[" hashtagContentPart* "]"
-	/ "「" hashtagContentPart* "」"
+	= "(" hashPairInner ")"
+	/ "[" hashPairInner "]"
+	/ "「" hashPairInner "」"
+
+hashPairInner
+	= &{ return enterNest(); } @(@hashtagContentPart* &{ return leaveNest(); } / &{ return fallbackNest(); })
 
 hashtagChar
 	= ![ 　\t.,!?'"#:\/\[\]【】()「」<>] CHAR

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -364,24 +364,18 @@ mention
 }
 
 mentionName
-	= !"-" mentionNamePart+ // first char is not "-".
+	= [a-z0-9_]i (&("-"+ [a-z0-9_]i) . / [a-z0-9_]i)*
 {
 	return text();
 }
-
-mentionNamePart
-	= "-" &mentionNamePart // last char is not "-".
-	/ [a-z0-9_]i
+// NOTE: first char and last char are not "-".
 
 mentionHost
-	= ![.-] mentionHostPart+ // first char is neither "." nor "-".
+	= [a-z0-9_]i (&([.-]i+ [a-z0-9_]i) . / [a-z0-9_]i)*
 {
 	return text();
 }
-
-mentionHostPart
-	= [.-] &mentionHostPart // last char is neither "." nor "-".
-	/ [a-z0-9_]i
+// NOTE: first char and last char are neither "." nor "-".
 
 // inline: hashtag
 

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -424,7 +424,7 @@ link
 }
 
 linkLabel
-	= (!"]" linkLabelPart)+
+	= $(!"]" linkLabelPart)+
 
 linkLabelPart
 	= emojiCode

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -396,9 +396,9 @@ hashtagContentPart
 	/ hashtagChar
 
 hashtagBracketPair
-	= "(" hashtagContent* ")"
-	/ "[" hashtagContent* "]"
-	/ "「" hashtagContent* "」"
+	= "(" hashtagContentPart* ")"
+	/ "[" hashtagContentPart* "]"
+	/ "「" hashtagContentPart* "」"
 
 hashtagChar
 	= ![ 　\t.,!?'"#:\/\[\]【】()「」<>] CHAR

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -64,6 +64,28 @@
 		}
 		return options.fnNameList.includes(name);
 	}
+
+	// fn
+
+	const fnDepthLimit = options.fnDepthLimit || 10;
+	let fnDepth = 0;
+	function enterFn() {
+		if (fnDepth + 1 > fnDepthLimit) {
+			return false;
+		}
+		fnDepth++;
+		return true;
+	}
+
+	function leaveFn() {
+		fnDepth--;
+		return true;
+	}
+
+	function fallbackFn() {
+		fnDepth--;
+		return false;
+	}
 }
 
 //
@@ -419,11 +441,14 @@ linkLabelPart
 // inline: fn
 
 fn
-	= "$[" name:$([a-z0-9_]i)+ &{ return ensureFnName(name); } args:fnArgs? _ content:(!("]") @inline)+ "]"
+	= "$[" name:$([a-z0-9_]i)+ &{ return ensureFnName(name); } args:fnArgs? _ content:fnContent "]"
 {
 	args = args || {};
 	return FN(name, args, mergeText(content));
 }
+
+fnContent
+	= &{ return enterFn(); } @(@(!("]") @inline)+ &{ return leaveFn(); } / &{ return fallbackFn(); })
 
 fnArgs
 	= "." head:fnArg tails:("," @fnArg)*

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -409,35 +409,23 @@ hashtagChar
 // inline: URL
 
 url
-	= "<" url:altUrlFormat ">"
+	= "<" url:$("http" "s"? "://" (!(">" / _) CHAR)+) ">"
 {
 	return N_URL(url, true);
 }
-	/ url:urlFormat
+	/ "http" "s"? "://" (&([.,]+ urlContentPart) . / urlContentPart)+
 {
-	return N_URL(url);
-}
-
-urlFormat
-	= "http" "s"? "://" urlContentPart+
-{
-	return text();
+	// NOTE: last char is neither "." nor ",".
+	return N_URL(text());
 }
 
 urlContentPart
-	= urlBracketPair
-	/ [.,] &urlContentPart // last char is neither "." nor ",".
+	= "(" urlPairInner ")"
+	/ "[" urlPairInner "]"
 	/ [a-z0-9_/:%#@$&?!~=+-]i
 
-urlBracketPair
-	= "(" urlContentPart* ")"
-	/ "[" urlContentPart* "]"
-
-altUrlFormat
-	= "http" "s"? "://" (!(">" / _) CHAR)+
-{
-	return text();
-}
+urlPairInner
+	= &{ return enterNest(); } @(@(urlContentPart / [.,])* &{ return leaveNest(); } / &{ return fallbackNest(); })
 
 // inline: link
 

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -436,13 +436,21 @@ link
 }
 
 linkLabel
-	= linkLabelPart+
+	= (!"]" linkLabelPart)+
 
 linkLabelPart
-	= url { return text(); /* text node */ }
-	/ link { return text(); /* text node */ }
-	/ mention { return text(); /* text node */ }
-	/ !"]" @inline
+	= emojiCode
+	/ unicodeEmoji
+	/ big
+	/ bold
+	/ small
+	/ italic
+	/ strike
+	/ inlineCode
+	/ mathInline
+	/ hashtag
+	/ fn
+	/ inlineText
 
 // inline: fn
 

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -252,19 +252,22 @@ unicodeEmoji
 // inline: big
 
 big
-	= "***" content:(!"***" @inline)+ "***"
+	= "***" content:bigContent "***"
 {
 	return FN('tada', { }, mergeText(content));
 }
 
+bigContent
+	= &{ return enterNest(); } @(@(!"***" @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
+
 // inline: bold
 
 bold
-	= "**" content:(!"**" @inline)+ "**"
+	= "**" content:boldContent "**"
 {
 	return BOLD(mergeText(content));
 }
-	/ "<b>" content:(!"</b>" @inline)+ "</b>"
+	/ "<b>" content:boldTagContent "</b>"
 {
 	return BOLD(mergeText(content));
 }
@@ -274,13 +277,22 @@ bold
 	return BOLD(parsedContent);
 }
 
+boldContent
+	= &{ return enterNest(); } @(@(!"**" @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
+
+boldTagContent
+	= &{ return enterNest(); } @(@(!"</b>" @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
+
 // inline: small
 
 small
-	= "<small>" content:(!"</small>" @inline)+ "</small>"
+	= "<small>" content:smallContent "</small>"
 {
 	return SMALL(mergeText(content));
 }
+
+smallContent
+	= &{ return enterNest(); } @(@(!"</small>" @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
 
 // inline: italic
 
@@ -289,10 +301,13 @@ italic
 	/ italicAlt
 
 italicTag
-	= "<i>" content:(!"</i>" @inline)+ "</i>"
+	= "<i>" content:italicContent "</i>"
 {
 	return ITALIC(mergeText(content));
 }
+
+italicContent
+	= &{ return enterNest(); } @(@(!"</i>" @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
 
 italicAlt
 	= "*" content:$(!"*" ([a-z0-9]i / _))+ "*" &(EOF / LF / _ / ![a-z0-9]i)
@@ -309,14 +324,20 @@ italicAlt
 // inline: strike
 
 strike
-	= "~~" content:(!("~" / LF) @inline)+ "~~"
+	= "~~" content:strikeContent "~~"
 {
 	return STRIKE(mergeText(content));
 }
-	/ "<s>" content:(!("</s>" / LF) @inline)+ "</s>"
+	/ "<s>" content:strikeTagContent "</s>"
 {
 	return STRIKE(mergeText(content));
 }
+
+strikeContent
+	= &{ return enterNest(); } @(@(!("~" / LF) @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
+
+strikeTagContent
+	= &{ return enterNest(); } @(@(!("</s>" / LF) @inline)+ &{ return leaveNest(); } / &{ return fallbackNest(); })
 
 // inline: inlineCode
 

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -67,7 +67,7 @@
 
 	// nesting control
 
-	const nestLimit = options.nestLimit || 10;
+	const nestLimit = options.nestLimit || 20;
 	let depth = 0;
 	function enterNest() {
 		if (depth + 1 > nestLimit) {

--- a/src/internal/parser.pegjs
+++ b/src/internal/parser.pegjs
@@ -424,7 +424,7 @@ link
 }
 
 linkLabel
-	= $(!"]" linkLabelPart)+
+	= (!"]" @linkLabelPart)+
 
 linkLabelPart
 	= emojiCode

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -984,18 +984,6 @@ hoge`;
 			assert.deepStrictEqual(mfm.parse(input), output);
 		});
 
-		it('do not yield link node even if label is recognisable as a link', () => {
-			const input = 'official instance: [[https://misskey.io/@ai](https://misskey.io/@ai)](https://misskey.io/@ai).';
-			const output = [
-				TEXT('official instance: '),
-				LINK(false, 'https://misskey.io/@ai', [
-					TEXT('[https://misskey.io/@ai](https://misskey.io/@ai)')
-				]),
-				TEXT('.')
-			];
-			assert.deepStrictEqual(mfm.parse(input), output);
-		});
-
 		it('do not yield mention', () => {
 			const input = '[@example](https://example.com)';
 			const output = [

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -984,6 +984,20 @@ hoge`;
 			assert.deepStrictEqual(mfm.parse(input), output);
 		});
 
+		it('cannot nest a link in a link label', () => {
+			const input = 'official instance: [[https://misskey.io/@ai](https://misskey.io/@ai)](https://misskey.io/@ai).';
+			const output = [
+				TEXT('official instance: '),
+				LINK(false, 'https://misskey.io/@ai', [
+					TEXT('[https://misskey.io/@ai')
+				]),
+				TEXT(']('),
+				N_URL('https://misskey.io/@ai'),
+				TEXT(').'),
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
 		it('do not yield mention', () => {
 			const input = '[@example](https://example.com)';
 			const output = [

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -1069,6 +1069,142 @@ hoge`;
 		});
 	});
 
+	describe('nesting limit', () => {
+		it('big', () => {
+			const input = '<b><b>***abc***</b></b>';
+			const output = [
+				BOLD([
+					BOLD([
+						TEXT('**'),
+						ITALIC([
+							TEXT('abc'),
+						]),
+						TEXT('**'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+		});
+
+		describe('bold', () => {
+			it('basic', () => {
+				const input = '<i><i>**abc**</i></i>';
+				const output = [
+					ITALIC([
+						ITALIC([
+							TEXT('*'),
+							ITALIC([
+								TEXT('abc'),
+							]),
+							TEXT('*'),
+						]),
+					]),
+				];
+				assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+			});
+
+			it('tag', () => {
+				const input = '<i><i><b>abc</b></i></i>';
+				const output = [
+					ITALIC([
+						ITALIC([
+							TEXT('<b>abc</b>'),
+						]),
+					]),
+				];
+				assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+			});
+		});
+
+		it('small', () => {
+			const input = '<i><i><small>abc</small></i></i>';
+			const output = [
+				ITALIC([
+					ITALIC([
+						TEXT('<small>abc</small>'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+		});
+
+		it('italic', () => {
+			const input = '<b><b><i>abc</i></b></b>';
+			const output = [
+				BOLD([
+					BOLD([
+						TEXT('<i>abc</i>'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+		});
+
+		describe('strike', () => {
+			it('basic', () => {
+				const input = '<b><b>~~abc~~</b></b>';
+				const output = [
+					BOLD([
+						BOLD([
+							TEXT('~~abc~~'),
+						]),
+					]),
+				];
+				assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+			});
+	
+			it('tag', () => {
+				const input = '<b><b><s>abc</s></b></b>';
+				const output = [
+					BOLD([
+						BOLD([
+							TEXT('<s>abc</s>'),
+						]),
+					]),
+				];
+				assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+			});
+		});
+
+		it('hashtag', () => {
+			const input = '<b><b>#abc(xyz)</b></b>';
+			const output = [
+				BOLD([
+					BOLD([
+						HASHTAG('abc'),
+						TEXT('(xyz)'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+		});
+
+		it('url', () => {
+			const input = '<b><b>https://example.com/abc(xyz)</b></b>';
+			const output = [
+				BOLD([
+					BOLD([
+						N_URL('https://example.com/abc'),
+						TEXT('(xyz)'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+		});
+
+		it('fn', () => {
+			const input = '<b><b>$[a b]</b></b>';
+			const output = [
+				BOLD([
+					BOLD([
+						TEXT('$[a b]'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input, { nestLimit: 2 }), output);
+		});
+	});
+
 	it('composite', () => {
 		const input =
 `before


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey.js/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey.js/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

構文のネスト回数を制限できるようにする。
Resolve #56 

## 方針
できるだけ再帰するルールを無くして、どうしても再帰が必要になる場合にネスト回数のカウント・マッチ制限を行う。

## nestLimitオプションの追加
`parse()`にnestLimitオプションを追加。
ネスト制限が導入されたいずれかの構文で合計のネスト回数がnestLimitを超えると、ネスト制限された構文にマッチしなくなる。
デフォルトは20回。

## リンクラベルの仕様変更
リンクラベルにlinkに含められるようにする仕様があったため、再帰が必要になっていた。
仕様を簡素化して関連するテストを削除。

## ネスト制限を導入する構文
- big
- bold
- small
- italic
- strike
- hashtag (括弧ペアで囲まれた部分)
- url (括弧ペアで囲まれた部分)
- fn

## 再帰しないようにルールを変更する構文
- mention
- link

## 補足説明
`enterNest()`と`leaveNest()`で挟んだ部分はネストしている部分として扱われ、ネスト回数がインクリメントされる。
もしネスト部分のマッチに失敗した場合は、優先度付き選択の結果`fallbackNest()`が実行される。
ストレートにマッチした場合はここを通過しない。
