### PR TITLE
Potentially invalid emoji code (detect preceding alphanumeric character)

### DIFF
--- a/src/internal/core/index.ts
+++ b/src/internal/core/index.ts
@@ -202,6 +202,15 @@ export function notMatch(parser: Parser<unknown>): Parser<null> {
 	});
 }
 
+export function notRegexpBefore<T extends RegExp>(pattern: T): Parser<null> {
+	return new Parser((input, index, _state) => {
+		const beforeStr = input.slice(0, index);
+		return !pattern.test(beforeStr)
+			? success(index, null)
+			: failure();
+	});
+}
+
 export const cr = str('\r');
 export const lf = str('\n');
 export const crlf = str('\r\n');

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -392,6 +392,7 @@ export const language = P.createLanguage<TypeTable>({
 	italicAsta: () => {
 		const mark = P.str('*');
 		const parser = P.seq(
+			P.notRegexpBefore(/[a-z0-9]$/i),
 			mark,
 			P.alt([alphaAndNum, space]).many(1),
 			mark,
@@ -401,18 +402,14 @@ export const language = P.createLanguage<TypeTable>({
 			if (!result.success) {
 				return P.failure();
 			}
-			// check before
-			const beforeStr = input.slice(0, index);
-			if (/[a-z0-9]$/i.test(beforeStr)) {
-				return P.failure();
-			}
-			return P.success(result.index, M.ITALIC(mergeText(result.value[1])));
+			return P.success(result.index, M.ITALIC(mergeText(result.value[2])));
 		});
 	},
 
 	italicUnder: () => {
 		const mark = P.str('_');
 		const parser = P.seq(
+			P.notRegexpBefore(/[a-z0-9]$/i),
 			mark,
 			P.alt([alphaAndNum, space]).many(1),
 			mark,
@@ -422,12 +419,7 @@ export const language = P.createLanguage<TypeTable>({
 			if (!result.success) {
 				return P.failure();
 			}
-			// check before
-			const beforeStr = input.slice(0, index);
-			if (/[a-z0-9]$/i.test(beforeStr)) {
-				return P.failure();
-			}
-			return P.success(result.index, M.ITALIC(mergeText(result.value[1])));
+			return P.success(result.index, M.ITALIC(mergeText(result.value[2])));
 		});
 	},
 
@@ -551,6 +543,7 @@ export const language = P.createLanguage<TypeTable>({
 	mention: () => {
 		const parser = P.seq(
 			notLinkLabel,
+			P.notRegexpBefore(/[a-z0-9]$/i),
 			P.str('@'),
 			P.regexp(/[a-z0-9_-]+/i),
 			P.seq(
@@ -564,15 +557,10 @@ export const language = P.createLanguage<TypeTable>({
 			if (!result.success) {
 				return P.failure();
 			}
-			// check before (not mention)
-			const beforeStr = input.slice(0, index);
-			if (/[a-z0-9]$/i.test(beforeStr)) {
-				return P.failure();
-			}
 			let invalidMention = false;
 			const resultIndex = result.index;
-			const username: string = result.value[2];
-			const hostname: string | null = result.value[3];
+			const username: string = result.value[3];
+			const hostname: string | null = result.value[4];
 			// remove [.-] of tail of hostname
 			let modifiedHost = hostname;
 			if (hostname != null) {
@@ -637,17 +625,13 @@ export const language = P.createLanguage<TypeTable>({
 		]));
 		const parser = P.seq( 
 			notLinkLabel,
+			P.notRegexpBefore(/[a-z0-9]$/i),
 			mark,
 			innerItem.many(1).text(),
-		).select(2);
+		).select(3);
 		return new P.Parser((input, index, state) => {
 			const result = parser.handler(input, index, state);
 			if (!result.success) {
-				return P.failure();
-			}
-			// check before
-			const beforeStr = input.slice(0, index);
-			if (/[a-z0-9]$/i.test(beforeStr)) {
 				return P.failure();
 			}
 			const resultIndex = result.index;

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -645,14 +645,13 @@ export const language = P.createLanguage<TypeTable>({
 	},
 
 	emojiCode: () => {
-		const side = P.notMatch(P.regexp(/[a-z0-9]/i));
 		const mark = P.str(':');
 		return P.seq( 
-			P.alt([P.lineBegin, side]),
+			P.notRegexpBefore(/[a-z0-9]$/i),
 			mark,
 			P.regexp(/[a-z0-9_+-]+/i),
 			mark,
-			P.alt([P.lineEnd, side]),
+			P.alt([P.lineEnd, P.notMatch(P.regexp(/[a-z0-9]/i))]),
 		).select(2).map(name => M.EMOJI_CODE(name));
 	},
 

--- a/test/api.ts
+++ b/test/api.ts
@@ -204,7 +204,6 @@ after`;
 		test('nested', () => {
 			const nodes = mfm.parse('abc:hoge:$[tada 123 @hoge :foo:]:piyo:');
 			const expect = [
-				EMOJI_CODE('hoge'),
 				EMOJI_CODE('foo'),
 				EMOJI_CODE('piyo')
 			];

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -49,6 +49,12 @@ describe('SimpleParser', () => {
 			const output = [TEXT('あ'), EMOJI_CODE('bar'), TEXT('い')];
 			assert.deepStrictEqual(mfm.parseSimple(input), output);
 		});
+
+		test('end of text', () => {
+			const input = 'At 10:30:';
+			const output = [TEXT('At 10:30:')];
+			assert.deepStrictEqual(mfm.parseSimple(input), output);
+		});
 	});
 
 	test('disallow other syntaxes', () => {


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey.js/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey.js/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

The intention seems to be to detect if there are any alphanumerics on either side of an emoji code. (See #129.)
However, the code as it is currently written only detects the case for alphanumerics **after** an emoji code.

In other words, the current behaviour is: (以前の動作:)

```
  x:e:x       ⇒  TEXT('x:e:x')
   :e:x       ⇒  TEXT(':e:x')
  x:e:        ⇒  TEXT('x'), EMOJI_CODE('e')
```  

We change this behaviour as so: (新しい動作:)

```
  x:e:x       ⇒  TEXT('x:e:x')
   :e:x       ⇒  TEXT(':e:x')
  x:e:        ⇒  TEXT('x:e:')
```  

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Example note text that would trigger this:
```
8:30: Breakfast
9:00: Presentation 
12:30: Lunch
```

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

We also extract `notRegexpBefore` as it is a pattern seen elsewhere in the code.

If this is considered "not a bug" I am happy for this to be closed.