### PR TITLE
feat: Add parseHtml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 -->
 
+## Unreleased
+### Features
+- Add parseHtml
+
 ## 0.24.0
 ### Features
 - Supports Unicode 15.0 emoji

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ https://github.com/syuilo/ai
 // Generate a MFM tree from the full MFM text.
 const mfmTree = mfm.parse(inputText);
 
+// Generate a MFM tree from the html MFM text.
+const htmlMfmTree = mfm.parseHtml(inputText);
+
 // Generate a MFM tree from the simple MFM text.
 const simpleMfmTree = mfm.parseSimple('I like the hot soup :soup:​');
 
@@ -60,6 +63,11 @@ npm run build
 full parser:
 ```
 npm run parse
+```
+
+html parser:
+```
+npm run parse-html
 ```
 
 simple parser:

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,27 @@ console.log(JSON.stringify(nodes));
 // => [{"type":"bold","children":[{"type":"text","props":{"text":"<s>cannot nest</s>"}}]}]
 ```
 
+## parseHtml API
+入力文字列からノードツリーを生成します。  
+MFM構文のうち、HTML、メンション、ハッシュタグ、URL、絵文字コード、Unicode絵文字を利用可能です。  
+
+例:  
+```ts
+const nodes = mfm.parseHtml('hello @syuilo');
+console.log(JSON.stringify(nodes));
+// => [{"type":"text","props":{"text":"hello "}},{"type":"mention","props":{"username":"syuilo","host":null,"acct":"@syuilo"}}]
+```
+
+### 最大のネストの深さを変更する
+デフォルトで20に設定されています。  
+
+例:  
+```ts
+const nodes = mfm.parseHtml('<b><s>cannot nest</s></b>', { nestLimit: 1 });
+console.log(JSON.stringify(nodes));
+// => [{"type":"bold","children":[{"type":"text","props":{"text":"<s>cannot nest</s>"}}]}]
+```
+
 ## parseSimple API
 入力文字列からノードツリーを生成します。  
 絵文字コードとUnicode絵文字を利用可能です。  

--- a/etc/mfm-js.api.md
+++ b/etc/mfm-js.api.md
@@ -105,6 +105,9 @@ export type MfmHashtag = {
 };
 
 // @public (undocumented)
+export type MfmHtmlNode = MfmCenter | MfmInline;
+
+// @public (undocumented)
 export type MfmInline = MfmUnicodeEmoji | MfmEmojiCode | MfmBold | MfmSmall | MfmItalic | MfmStrike | MfmInlineCode | MfmMathInline | MfmMention | MfmHashtag | MfmUrl | MfmLink | MfmFn | MfmPlain | MfmText;
 
 // @public (undocumented)
@@ -244,6 +247,11 @@ export type NodeType<T extends MfmNode['type']> = T extends 'quote' ? MfmQuote :
 export function parse(input: string, opts?: Partial<{
     nestLimit: number;
 }>): MfmNode[];
+
+// @public (undocumented)
+export function parseHtml(input: string, opts?: Partial<{
+    nestLimit: number;
+}>): MfmHtmlNode[];
 
 // @public (undocumented)
 export function parseSimple(input: string): MfmSimpleNode[];

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "tsc": "tsc",
     "tsd": "tsd",
     "parse": "node ./built/cli/parse",
+    "parse-html": "node ./built/cli/parseHtml",
     "parse-simple": "node ./built/cli/parseSimple",
     "api": "npx api-extractor run --local --verbose",
     "api-prod": "npx api-extractor run --verbose",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,22 @@
-import { fullParser, simpleParser } from './internal';
+import { fullParser, simpleParser, htmlParser } from './internal';
 import { inspectOne, stringifyNode, stringifyTree } from './internal/util';
-import { MfmNode, MfmSimpleNode } from './node';
+import { MfmNode, MfmHtmlNode, MfmSimpleNode } from './node';
 
 /**
  * Generates a MfmNode tree from the MFM string.
 */
 export function parse(input: string, opts: Partial<{ nestLimit: number; }> = {}): MfmNode[] {
 	const nodes = fullParser(input, {
+		nestLimit: opts.nestLimit,
+	});
+	return nodes;
+}
+
+/**
+ * Generates a MfmHtmlNode tree from the MFM string.
+*/
+export function parseHtml(input: string, opts: Partial<{ nestLimit: number; }> = {}): MfmHtmlNode[] {
+	const nodes = htmlParser(input, {
 		nestLimit: opts.nestLimit,
 	});
 	return nodes;

--- a/src/cli/parseHtml.ts
+++ b/src/cli/parseHtml.ts
@@ -1,0 +1,47 @@
+import { performance } from 'perf_hooks';
+import inputLine, { InputCanceledError } from './misc/inputLine';
+import { parseHtml } from '..';
+
+async function entryPoint(): Promise<void> {
+	console.log('intaractive parser');
+
+	while (true) {
+		let input: string;
+		try {
+			input = await inputLine('> ');
+		}
+		catch (err) {
+			if (err instanceof InputCanceledError) {
+				console.log('bye.');
+				return;
+			}
+			throw err;
+		}
+
+		// replace special chars
+		input = input
+			.replace(/\\n/g, '\n')
+			.replace(/\\t/g, '\t')
+			.replace(/\\u00a0/g, '\u00a0');
+
+		try {
+			const parseTimeStart = performance.now();
+			const result = parseHtml(input);
+			const parseTimeEnd = performance.now();
+			console.log(JSON.stringify(result));
+			const parseTime = (parseTimeEnd - parseTimeStart).toFixed(3);
+			console.log(`parsing time: ${parseTime}ms`);
+		}
+		catch (err) {
+			console.log('parsing error:');
+			console.log(err);
+		}
+		console.log();
+	}
+}
+
+entryPoint()
+	.catch(err => {
+		console.log(err);
+		process.exit(1);
+	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
 	parse,
+	parseHtml,
 	parseSimple,
 	toString,
 	inspect,
@@ -9,6 +10,7 @@ export {
 export {
 	NodeType,
 	MfmNode,
+	MfmHtmlNode,
 	MfmSimpleNode,
 	MfmBlock,
 	MfmInline,

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -17,6 +17,17 @@ export function fullParser(input: string, opts: FullParserOpts): M.MfmNode[] {
 	return mergeText(result.value);
 }
 
+export function htmlParser(input: string, opts: FullParserOpts): M.MfmHtmlNode[] {
+	const result = language.htmlParser.handler(input, 0, {
+		nestLimit: (opts.nestLimit != null) ? opts.nestLimit : 20,
+		depth: 0,
+		linkLabel: false,
+		trace: false,
+	});
+	if (!result.success) throw new Error('Unexpected parse error');
+	return mergeText(result.value);
+}
+
 export function simpleParser(input: string): M.MfmSimpleNode[] {
 	const result = language.simpleParser.handler(input, 0, {
 		depth: 0,

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,7 @@
 export type MfmNode = MfmBlock | MfmInline;
 
+export type MfmHtmlNode = MfmCenter | MfmInline;
+
 export type MfmSimpleNode = MfmUnicodeEmoji | MfmEmojiCode | MfmText | MfmPlain;
 
 export type MfmBlock = MfmQuote | MfmSearch | MfmCodeBlock | MfmMathBlock | MfmCenter;


### PR DESCRIPTION
# What
parseHtml APIを追加し、MFM未対応実装のNoteに含まれるHTMLを期待通りにパースできるようにします。

# Why
MFM未対応実装のNoteに含まれるHTMLは、従来のparse APIでは投稿者が意図していない解釈となります。

MFM構文のうち、対応HTMLタグ、メンション、ハッシュタグ、URL、絵文字コード、Unicode絵文字のみパースするAPIを追加することにより、過剰な解釈を行わず、適切に解釈できる機能を提供します。

# Additional info (optional)
Fix https://github.com/misskey-dev/mfm.js/issues/155
See https://github.com/misskey-dev/misskey/issues/15217