### PR TITLE
リスト構文の追加

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -2,6 +2,7 @@
 
 ブロック構文:
 - [引用ブロック](#quote)
+- [リスト](#list)
 - [検索ブロック](#search)
 - [コードブロック](#code-block)
 - [数式ブロック](#math-block)
@@ -48,6 +49,37 @@
   type: 'quote',
   children: [
     { type: 'text', props: { text: 'abc' } }
+  ]
+}
+```
+
+
+
+<h1 id="list">Block: リスト</h1>
+
+## 形式
+```
+- abc
+-123
+```
+
+## ノード
+```js
+{
+  type: 'list',
+  children: [
+		{
+			type: 'listItem',
+			children: [
+    		{ type: 'text', props: { text: 'abc' } }
+			]
+		},
+		{
+			type: 'listItem',
+			children: [
+    		{ type: 'text', props: { text: '123' } }
+			]
+		}
   ]
 }
 ```

--- a/etc/mfm-js.api.md
+++ b/etc/mfm-js.api.md
@@ -41,6 +41,12 @@ export const ITALIC: (children: MfmInline[]) => NodeType<"italic">;
 export const LINK: (silent: boolean, url: string, children: MfmInline[]) => NodeType<"link">;
 
 // @public (undocumented)
+export const LIST: (children: MfmListItem[]) => NodeType<"list">;
+
+// @public (undocumented)
+export const LIST_ITEM: (children: MfmInline[]) => NodeType<"listItem">;
+
+// @public (undocumented)
 export const MATH_BLOCK: (formula: string) => NodeType<"mathBlock">;
 
 // @public (undocumented)
@@ -50,7 +56,7 @@ export const MATH_INLINE: (formula: string) => NodeType<"mathInline">;
 export const MENTION: (username: string, host: string | null, acct: string) => NodeType<"mention">;
 
 // @public (undocumented)
-export type MfmBlock = MfmQuote | MfmSearch | MfmCodeBlock | MfmMathBlock | MfmCenter;
+export type MfmBlock = MfmQuote | MfmSearch | MfmCodeBlock | MfmMathBlock | MfmCenter | MfmList | MfmListItem;
 
 // @public (undocumented)
 export type MfmBold = {
@@ -130,6 +136,20 @@ export type MfmLink = {
         silent: boolean;
         url: string;
     };
+    children: MfmInline[];
+};
+
+// @public (undocumented)
+export type MfmList = {
+    type: 'list';
+    props?: Record<string, unknown>;
+    children: MfmListItem[];
+};
+
+// @public (undocumented)
+export type MfmListItem = {
+    type: 'listItem';
+    props?: Record<string, unknown>;
     children: MfmInline[];
 };
 
@@ -238,7 +258,7 @@ export type MfmUrl = {
 export const N_URL: (value: string, brackets?: boolean) => NodeType<"url">;
 
 // @public (undocumented)
-export type NodeType<T extends MfmNode['type']> = T extends 'quote' ? MfmQuote : T extends 'search' ? MfmSearch : T extends 'blockCode' ? MfmCodeBlock : T extends 'mathBlock' ? MfmMathBlock : T extends 'center' ? MfmCenter : T extends 'unicodeEmoji' ? MfmUnicodeEmoji : T extends 'emojiCode' ? MfmEmojiCode : T extends 'bold' ? MfmBold : T extends 'small' ? MfmSmall : T extends 'italic' ? MfmItalic : T extends 'strike' ? MfmStrike : T extends 'inlineCode' ? MfmInlineCode : T extends 'mathInline' ? MfmMathInline : T extends 'mention' ? MfmMention : T extends 'hashtag' ? MfmHashtag : T extends 'url' ? MfmUrl : T extends 'link' ? MfmLink : T extends 'fn' ? MfmFn : T extends 'plain' ? MfmPlain : T extends 'text' ? MfmText : never;
+export type NodeType<T extends MfmNode['type']> = T extends 'quote' ? MfmQuote : T extends 'list' ? MfmList : T extends 'listItem' ? MfmListItem : T extends 'search' ? MfmSearch : T extends 'blockCode' ? MfmCodeBlock : T extends 'mathBlock' ? MfmMathBlock : T extends 'center' ? MfmCenter : T extends 'unicodeEmoji' ? MfmUnicodeEmoji : T extends 'emojiCode' ? MfmEmojiCode : T extends 'bold' ? MfmBold : T extends 'small' ? MfmSmall : T extends 'italic' ? MfmItalic : T extends 'strike' ? MfmStrike : T extends 'inlineCode' ? MfmInlineCode : T extends 'mathInline' ? MfmMathInline : T extends 'mention' ? MfmMention : T extends 'hashtag' ? MfmHashtag : T extends 'url' ? MfmUrl : T extends 'link' ? MfmLink : T extends 'fn' ? MfmFn : T extends 'plain' ? MfmPlain : T extends 'text' ? MfmText : never;
 
 // @public (undocumented)
 export function parse(input: string, opts?: Partial<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
 	MfmMathBlock,
 	MfmCenter,
 	MfmList,
+	MfmListItem,
 
 	// inline
 	MfmUnicodeEmoji,
@@ -49,6 +50,7 @@ export {
 	MATH_BLOCK,
 	CENTER,
 	LIST,
+	LIST_ITEM,
 
 	// inline
 	UNI_EMOJI,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export {
 	CODE_BLOCK,
 	MATH_BLOCK,
 	CENTER,
+	LIST,
 
 	// inline
 	UNI_EMOJI,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
 	MfmCodeBlock,
 	MfmMathBlock,
 	MfmCenter,
+	MfmList,
 
 	// inline
 	MfmUnicodeEmoji,

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -71,6 +71,7 @@ interface TypeTable {
 	simple: M.MfmSimpleNode | string,
 	inline: M.MfmInline | string,
 	quote: M.NodeType<'quote'>,
+	list: M.NodeType<'list'>,
 	codeBlock: M.NodeType<'blockCode'>,
 	mathBlock: M.NodeType<'mathBlock'>,
 	centerTag: M.NodeType<'center'>,
@@ -142,6 +143,8 @@ export const language = P.createLanguage<TypeTable>({
 			r.inlineCode,
 			// ">" block
 			r.quote,
+			// "-"
+			r.list,
 			// "\\[" block
 			r.mathBlock,
 			// "\\("
@@ -257,6 +260,22 @@ export const language = P.createLanguage<TypeTable>({
 				return result;
 			}
 			return P.success(quoteIndex, M.QUOTE(mergeText(result.value)));
+		});
+	},
+
+	list: r => {
+		const lines: P.Parser<string[]> = P.seq(
+			P.lineBegin,
+			P.str('-'),
+			space.option(),
+			P.seq(P.notMatch(newLine), P.char).select(1).many(0).text(),
+		).select(3).sep(newLine, 1);
+		return P.seq(
+			newLine.option(),
+			lines,
+			newLine.option(),
+		).select(1).map(result => {
+			return M.LIST(result);
 		});
 	},
 

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -267,11 +267,13 @@ export const language = P.createLanguage<TypeTable>({
 	list: r => {
 		return P.seq(
 			newLine.option(),
+			newLine.option(),
 			P.lineBegin,
 			r.listItem.sep(newLine, 1),
 			P.lineEnd,
 			newLine.option(),
-		).select(2).map(result => {
+			newLine.option(),
+		).select(3).map(result => {
 			return M.LIST(result);
 		});
 	},

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -265,7 +265,7 @@ export const language = P.createLanguage<TypeTable>({
 	},
 
 	list: r => {
-		const listItem: M.MfmListItem = P.seq(
+		const listItem: P.Parser<M.MfmListItem> = P.seq(
 			P.str('-'),
 			space.option(),
 			P.seq(P.notMatch(newLine), nest(r.inline)).select(1).many(1),

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -277,7 +277,7 @@ export const language = P.createLanguage<TypeTable>({
 	},
 
 	listItem: r => {
-		const listItem: P.Parser<M.MfmListItem> = P.seq(
+		return P.seq(
 			P.str('-'),
 			space.option(),
 			P.seq(P.notMatch(newLine), nest(r.inline)).select(1).many(1),

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -72,6 +72,7 @@ interface TypeTable {
 	inline: M.MfmInline | string,
 	quote: M.NodeType<'quote'>,
 	list: M.NodeType<'list'>,
+	listItem: M.NodeType<'listItem'>,
 	codeBlock: M.NodeType<'blockCode'>,
 	mathBlock: M.NodeType<'mathBlock'>,
 	centerTag: M.NodeType<'center'>,
@@ -264,17 +265,20 @@ export const language = P.createLanguage<TypeTable>({
 	},
 
 	list: r => {
-		const lines: P.Parser<string[]> = P.seq(
-			P.lineBegin,
+		const listItem: M.MfmListItem = P.seq(
 			P.str('-'),
 			space.option(),
-			P.seq(P.notMatch(newLine), P.char).select(1).many(0).text(),
-		).select(3).sep(newLine, 1);
+			P.seq(P.notMatch(newLine), nest(r.inline)).select(1).many(1),
+		).select(2).map(result => {
+			return M.LIST_ITEM(result);
+		});
 		return P.seq(
 			newLine.option(),
-			lines,
+			P.lineBegin,
+			listItem.sep(newLine, 1),
+			P.lineEnd,
 			newLine.option(),
-		).select(1).map(result => {
+		).select(2).map(result => {
 			return M.LIST(result);
 		});
 	},

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -265,21 +265,24 @@ export const language = P.createLanguage<TypeTable>({
 	},
 
 	list: r => {
+		return P.seq(
+			newLine.option(),
+			P.lineBegin,
+			r.listItem.sep(newLine, 1),
+			P.lineEnd,
+			newLine.option(),
+		).select(2).map(result => {
+			return M.LIST(result);
+		});
+	},
+
+	listItem: r => {
 		const listItem: P.Parser<M.MfmListItem> = P.seq(
 			P.str('-'),
 			space.option(),
 			P.seq(P.notMatch(newLine), nest(r.inline)).select(1).many(1),
 		).select(2).map(result => {
 			return M.LIST_ITEM(mergeText(result));
-		});
-		return P.seq(
-			newLine.option(),
-			P.lineBegin,
-			listItem.sep(newLine, 1),
-			P.lineEnd,
-			newLine.option(),
-		).select(2).map(result => {
-			return M.LIST(result);
 		});
 	},
 

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -270,7 +270,7 @@ export const language = P.createLanguage<TypeTable>({
 			space.option(),
 			P.seq(P.notMatch(newLine), nest(r.inline)).select(1).many(1),
 		).select(2).map(result => {
-			return M.LIST_ITEM(result);
+			return M.LIST_ITEM(mergeText(result));
 		});
 		return P.seq(
 			newLine.option(),

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -144,7 +144,7 @@ export const language = P.createLanguage<TypeTable>({
 			r.inlineCode,
 			// ">" block
 			r.quote,
-			// "-"
+			// "-" block
 			r.list,
 			// "\\[" block
 			r.mathBlock,

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -51,6 +51,12 @@ export function stringifyNode(node: MfmNode): string {
 		case 'center': {
 			return `<center>\n${ stringifyTree(node.children) }\n</center>`;
 		}
+		case 'list': {
+			return stringifyTree(node.children);
+		}
+		case 'listItem': {
+			return `- ${ stringifyTree(node.children) }`;
+		}
 		// inline
 		case 'emojiCode': {
 			return `:${ node.props.name }:`;

--- a/src/node.ts
+++ b/src/node.ts
@@ -16,6 +16,13 @@ export type MfmQuote = {
 };
 export const QUOTE = (children: MfmNode[]): NodeType<'quote'> => { return { type: 'quote', children }; };
 
+export type MfmList = {
+	type: 'list';
+	props?: Record<string, unknown>;
+	children: MfmInline[];
+};
+export const LIST = (children: MfmInline[]): NodeType<'list'> => { return { type: 'list', children }; };
+
 export type MfmSearch = {
 	type: 'search';
 	props: {

--- a/src/node.ts
+++ b/src/node.ts
@@ -19,9 +19,9 @@ export const QUOTE = (children: MfmNode[]): NodeType<'quote'> => { return { type
 export type MfmList = {
 	type: 'list';
 	props?: Record<string, unknown>;
-	children: MfmList[];
+	children: MfmListItem[];
 };
-export const LIST = (children: MfmList[]): NodeType<'list'> => { return { type: 'list', children }; };
+export const LIST = (children: MfmListItem[]): NodeType<'list'> => { return { type: 'list', children }; };
 
 export type MfmListItem = {
 	type: 'listItem';

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,9 +2,9 @@ export type MfmNode = MfmBlock | MfmInline;
 
 export type MfmSimpleNode = MfmUnicodeEmoji | MfmEmojiCode | MfmText | MfmPlain;
 
-export type MfmBlock = MfmQuote | MfmSearch | MfmCodeBlock | MfmMathBlock | MfmCenter | MfmList;
+export type MfmBlock = MfmQuote | MfmSearch | MfmCodeBlock | MfmMathBlock | MfmCenter | MfmList | MfmListItem;
 
-const blockTypes: MfmNode['type'][] = ['quote', 'search', 'blockCode', 'mathBlock', 'center', 'list'];
+const blockTypes: MfmNode['type'][] = ['quote', 'search', 'blockCode', 'mathBlock', 'center', 'list', 'listItem'];
 export function isMfmBlock(node: MfmNode): node is MfmBlock {
 	return blockTypes.includes(node.type);
 }
@@ -19,9 +19,16 @@ export const QUOTE = (children: MfmNode[]): NodeType<'quote'> => { return { type
 export type MfmList = {
 	type: 'list';
 	props?: Record<string, unknown>;
+	children: MfmList[];
+};
+export const LIST = (children: MfmList[]): NodeType<'list'> => { return { type: 'list', children }; };
+
+export type MfmListItem = {
+	type: 'listItem';
+	props?: Record<string, unknown>;
 	children: MfmInline[];
 };
-export const LIST = (children: MfmInline[]): NodeType<'list'> => { return { type: 'list', children }; };
+export const LIST_ITEM = (children: MfmInline[]): NodeType<'listItem'> => { return { type: 'listItem', children }; };
 
 export type MfmSearch = {
 	type: 'search';
@@ -199,6 +206,7 @@ export const TEXT = (value: string): NodeType<'text'> => { return { type: 'text'
 export type NodeType<T extends MfmNode['type']> =
 	T extends 'quote' ? MfmQuote :
 	T extends 'list' ? MfmList :
+	T extends 'listItem' ? MfmList :
 	T extends 'search' ? MfmSearch :
 	T extends 'blockCode' ? MfmCodeBlock :
 	T extends 'mathBlock' ? MfmMathBlock :

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,9 +2,9 @@ export type MfmNode = MfmBlock | MfmInline;
 
 export type MfmSimpleNode = MfmUnicodeEmoji | MfmEmojiCode | MfmText | MfmPlain;
 
-export type MfmBlock = MfmQuote | MfmSearch | MfmCodeBlock | MfmMathBlock | MfmCenter;
+export type MfmBlock = MfmQuote | MfmSearch | MfmCodeBlock | MfmMathBlock | MfmCenter | MfmList;
 
-const blockTypes: MfmNode['type'][] = ['quote', 'search', 'blockCode', 'mathBlock', 'center'];
+const blockTypes: MfmNode['type'][] = ['quote', 'search', 'blockCode', 'mathBlock', 'center', 'list'];
 export function isMfmBlock(node: MfmNode): node is MfmBlock {
 	return blockTypes.includes(node.type);
 }
@@ -198,6 +198,7 @@ export const TEXT = (value: string): NodeType<'text'> => { return { type: 'text'
 
 export type NodeType<T extends MfmNode['type']> =
 	T extends 'quote' ? MfmQuote :
+	T extends 'list' ? MfmList :
 	T extends 'search' ? MfmSearch :
 	T extends 'blockCode' ? MfmCodeBlock :
 	T extends 'mathBlock' ? MfmMathBlock :

--- a/src/node.ts
+++ b/src/node.ts
@@ -206,7 +206,7 @@ export const TEXT = (value: string): NodeType<'text'> => { return { type: 'text'
 export type NodeType<T extends MfmNode['type']> =
 	T extends 'quote' ? MfmQuote :
 	T extends 'list' ? MfmList :
-	T extends 'listItem' ? MfmList :
+	T extends 'listItem' ? MfmListItem :
 	T extends 'search' ? MfmSearch :
 	T extends 'blockCode' ? MfmCodeBlock :
 	T extends 'mathBlock' ? MfmMathBlock :

--- a/test/api.ts
+++ b/test/api.ts
@@ -36,6 +36,13 @@ after`;
 			assert.strictEqual(mfm.toString(mfm.parse(input)), '> abc\n> \n> 123');
 		});
 
+		test('list', () => {
+			const input = `
+- item1
+- item2
+`;
+			assert.strictEqual(mfm.toString(mfm.parse(input)), '- item1\n- item2');
+		});
 
 		test('search', () => {
 			const input = 'MFM 書き方 123 Search';

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -2,7 +2,7 @@ import { describe, test } from 'vitest';
 import assert from 'assert';
 import * as mfm from '../src/index';
 import {
-	TEXT, CENTER, FN, UNI_EMOJI, MENTION, EMOJI_CODE, HASHTAG, N_URL, BOLD, SMALL, ITALIC, STRIKE, QUOTE, MATH_BLOCK, SEARCH, CODE_BLOCK, LINK, INLINE_CODE, MATH_INLINE, PLAIN
+	TEXT, CENTER, FN, UNI_EMOJI, MENTION, EMOJI_CODE, HASHTAG, N_URL, BOLD, SMALL, ITALIC, STRIKE, QUOTE, MATH_BLOCK, SEARCH, CODE_BLOCK, LINK, INLINE_CODE, MATH_INLINE, PLAIN, LIST, LIST_ITEM
 } from '../src/index';
 
 describe('SimpleParser', () => {
@@ -177,6 +177,138 @@ hoge`;
 					TEXT('bar')
 				]),
 				TEXT('hoge'),
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+	});
+
+	describe('list', () => {
+		test('1行のリストを使用できる', () => {
+			const input = '- abc';
+			const output = [
+				LIST([
+					LIST_ITEM([
+						TEXT('abc'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('2行のリストを使用できる', () => {
+			const input = '- abc\n- 123';
+			const output = [
+				LIST([
+					LIST_ITEM([
+						TEXT('abc'),
+					]),
+					LIST_ITEM([
+						TEXT('123'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('リストはブロックをネストできない', () => {
+			const input = `
+- <center>
+- a
+- </center>
+`;
+			const output = [
+				LIST([
+					LIST_ITEM([
+						TEXT('<center>'),
+					]),
+					LIST_ITEM([
+						TEXT('a'),
+					]),
+					LIST_ITEM([
+						TEXT('</center>'),
+					])
+				])
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('リストはインライン構文を含んだテキストをネストできる', () => {
+			const input = `
+- I'm @ai, An bot of misskey!
+`;
+			const output = [
+				LIST([
+					LIST_ITEM([
+						TEXT('I\'m '),
+						MENTION('ai', null, '@ai'),
+						TEXT(', An bot of misskey!'),
+					])
+				])
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('リスト項目を空にはできない', () => {
+			const input = '- ';
+			const output = [
+				TEXT('- ')
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('リストの前の空行は無視される', () => {
+			const input = `hoge
+
+- foo
+- bar
+`;
+			const output = [
+				TEXT('hoge'),
+				LIST([
+					LIST_ITEM([
+						TEXT('foo'),
+					]),
+					LIST_ITEM([
+						TEXT('bar'),
+					]),
+				]),
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('リストの後ろの空行は無視される', () => {
+			const input = `
+- foo
+- bar
+
+hoge`;
+			const output = [
+				LIST([
+					LIST_ITEM([
+						TEXT('foo'),
+					]),
+					LIST_ITEM([
+						TEXT('bar'),
+					]),
+				]),
+				TEXT('hoge'),
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('2つのリスト項目の間に空行があれば2つのリストが生成される', () => {
+			const input = '- abc\n\n- 123';
+			const output = [
+				LIST([
+					LIST_ITEM([
+						TEXT('abc'),
+					]),
+				]),
+				LIST([
+					LIST_ITEM([
+						TEXT('123'),
+					]),
+				]),
 			];
 			assert.deepStrictEqual(mfm.parse(input), output);
 		});


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey.js/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey.js/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
このPRではfull parserに対してリスト構文のパース処理を追加します。
ひとまず一段のリストのサポートが含まれます。

listノードおよびlistItemノードを追加します。

入力例:
```plain
- text1 **bold** :emoji:
- text2
```

生成されるノードツリー:
- list
  - listItem
    - text "text1 "
    - bold
      - text "bold"
    - text " "
    - emojiCode "emoji"
  - listItem
    - text "text2"

resolve #157 

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
