### PR TITLE
検索構文の書き方を一部廃止

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -58,8 +58,6 @@
 
 ## 形式
 ```
-MFM 書き方 Search
-MFM 書き方 検索
 MFM 書き方 [Search]
 MFM 書き方 [検索]
 ```

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -770,10 +770,14 @@ export const language = P.createLanguage<TypeTable>({
 	},
 
 	search: () => {
-		const button = P.alt([
-			P.regexp(/\[(検索|search)\]/i),
-			P.regexp(/(検索|search)/i),
-		]);
+		const button = P.seq(
+			P.str('['),
+			P.alt([
+				P.str('検索'),
+				P.str('search'),
+			]),
+			P.str(']'),
+		).text();
 		return P.seq(
 			newLine.option(),
 			P.lineBegin,

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -770,14 +770,7 @@ export const language = P.createLanguage<TypeTable>({
 	},
 
 	search: () => {
-		const button = P.seq(
-			P.str('['),
-			P.alt([
-				P.str('検索'),
-				P.str('search'),
-			]),
-			P.str(']'),
-		).text();
+		const button = P.regexp(/\[(search|検索)\]/i);
 		return P.seq(
 			newLine.option(),
 			P.lineBegin,

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -185,7 +185,7 @@ hoge`;
 	describe('search', () => {
 		describe('検索構文を使用できる', () => {
 			test('Search', () => {
-				const input = 'MFM 書き方 123 Search';
+				const input = 'MFM 書き方 123 [Search]';
 				const output = [
 					SEARCH('MFM 書き方 123', input)
 				];
@@ -198,22 +198,8 @@ hoge`;
 				];
 				assert.deepStrictEqual(mfm.parse(input), output);
 			});
-			test('search', () => {
-				const input = 'MFM 書き方 123 search';
-				const output = [
-					SEARCH('MFM 書き方 123', input)
-				];
-				assert.deepStrictEqual(mfm.parse(input), output);
-			});
 			test('[search]', () => {
 				const input = 'MFM 書き方 123 [search]';
-				const output = [
-					SEARCH('MFM 書き方 123', input)
-				];
-				assert.deepStrictEqual(mfm.parse(input), output);
-			});
-			test('検索', () => {
-				const input = 'MFM 書き方 123 検索';
 				const output = [
 					SEARCH('MFM 書き方 123', input)
 				];
@@ -228,10 +214,10 @@ hoge`;
 			});
 		});
 		test('ブロックの前後にあるテキストが正しく解釈される', () => {
-			const input = 'abc\nhoge piyo bebeyo 検索\n123';
+			const input = 'abc\nhoge piyo bebeyo [検索]\n123';
 			const output = [
 				TEXT('abc'),
-				SEARCH('hoge piyo bebeyo', 'hoge piyo bebeyo 検索'),
+				SEARCH('hoge piyo bebeyo', 'hoge piyo bebeyo [検索]'),
 				TEXT('123')
 			];
 			assert.deepStrictEqual(mfm.parse(input), output);


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey.js/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey.js/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
検索構文において`text 123 search`のようにボタン部分が`[]`で囲まれていない書き方を廃止する。
Related #122 

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
関連するテストは削除しています。
