### PR TITLE
enhance: support text escaping (#152)

### DIFF
--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -16,6 +16,7 @@ type Args = Record<string, string | true>;
 const space = P.regexp(/[\u0020\u3000\t]/);
 const alphaAndNum = P.regexp(/[a-z0-9]/i);
 const newLine = P.alt([P.crlf, P.cr, P.lf]);
+const asciiPunctuation = P.regexp(/[!#$%&'()*+,-./:;<=>?@\[\\\]^_`{|}~]/);
 
 function seqOrText<Parsers extends P.Parser<unknown>[]>(...parsers: Parsers): P.Parser<SeqParseResult<Parsers> | string> {
 	return new P.Parser<SeqParseResult<Parsers> | string>((input, index, state) => {
@@ -794,5 +795,10 @@ export const language = P.createLanguage<TypeTable>({
 		});
 	},
 
-	text: () => P.char,
+	text: () => {
+		return P.alt([
+			P.seq(P.str('\\'), asciiPunctuation).select(1),
+			P.char,
+		]);
+	},
 });

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -303,14 +303,14 @@ hoge`;
 		test('行末以外に閉じタグがある場合はマッチしない', () => {
 			const input = '\\[aaa\\]after';
 			const output = [
-				TEXT('\\[aaa\\]after')
+				TEXT('[aaa]after')
 			];
 			assert.deepStrictEqual(mfm.parse(input), output);
 		});
 		test('行頭以外に開始タグがある場合はマッチしない', () => {
 			const input = 'before\\[aaa\\]';
 			const output = [
-				TEXT('before\\[aaa\\]')
+				TEXT('before[aaa]')
 			];
 			assert.deepStrictEqual(mfm.parse(input), output);
 		});
@@ -1084,6 +1084,28 @@ hoge`;
 				TEXT('.')
 			];
 			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('with escaped text', () => {
+			const input = 'Ai said: ["Misskey.io \\[is\\] the official instance"](https://xn--931a.moe/).';
+			const output = [
+				TEXT('Ai said: '),
+				LINK(false, 'https://xn--931a.moe/', [
+					TEXT('"Misskey.io [is] the official instance"')
+				]),
+				TEXT('.')
+			];
+			assert.deepStrictEqual(mfm.parse(input), output);
+		});
+
+		test('with double escaped text', () => {
+			const input = 'Ai said: ["Misskey.io \\\\[is\\\\] the official instance"](https://xn--931a.moe/).';
+			const output = [
+				TEXT('Ai said: '),
+				LINK(false, 'https://xn--931a.moe/', [
+					TEXT('"Misskey.io \\[is\\] the official instance"')
+				]),
+			];
 		});
 
 		test('with angle brackets url', () => {


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey.js/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey.js/blob/develop/docs/CONTRIBUTING.en.md
-->

# What

タイトル通り

# Why


Fixes #152.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

I did modify 2 existing tests but I think the correct parse should be the new one. According to [CommonMark](https://spec.commonmark.org/0.31.2/#backslash-escapes) escapes should apply to all ASCII punctuation.
