### PR TITLE
Release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,17 @@
 
 -->
 ## 0.x.x (unreleased)
+
+## 0.26.0
 ### Features
 - Supports Unicode 17.0 emoji
+
+### Improvements
+- Expose `isMfmBlock` utility.
+
+### Changes
+- Package now ships both ESM and CJS builds.
+- Package now exposes main entry point only. Other independent files are no longer importable.
 
 ## 0.25.0
 ### Features

--- a/etc/mfm-js.api.md
+++ b/etc/mfm-js.api.md
@@ -35,6 +35,9 @@ export function inspect(node: MfmNode, action: (node: MfmNode) => void): void;
 export function inspect(nodes: MfmNode[], action: (node: MfmNode) => void): void;
 
 // @public (undocumented)
+export function isMfmBlock(node: MfmNode): node is MfmBlock;
+
+// @public (undocumented)
 export const ITALIC: (children: MfmInline[]) => NodeType<"italic">;
 
 // @public (undocumented)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mfm-js",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mfm-js",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@misskey-dev/emoji-data": "17.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mfm-js",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "An MFM parser implementation with TypeScript",
   "type": "module",
   "main": "./built/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,4 +64,7 @@ export {
 	FN,
 	PLAIN,
 	TEXT,
+
+	// util
+	isMfmBlock,
 } from './node';


### PR DESCRIPTION
## 0.26.0
### Features
- Supports Unicode 17.0 emoji

### Improvements
- Expose `isMfmBlock` utility

### Changes
- Package now ships both ESM and CJS builds.
- Package now exposes main entry point only. Other independent files are no longer importable.
